### PR TITLE
fix(actions): sticking to the tag version instead of master branch in the shared GitHub action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
 
       - id: deploy-staging
-        uses: WalletConnect/actions/actions/deploy-terraform/@master
+        uses: WalletConnect/actions/actions/deploy-terraform/@2.4.3
         env:
           TF_VAR_node_env: staging
           TF_VAR_supabase_jwt_secret: ${{ secrets.SUPABASE_JWT_SECRET }}
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v3
 
       - id: deploy-prod
-        uses: WalletConnect/actions/actions/deploy-terraform/@master
+        uses: WalletConnect/actions/actions/deploy-terraform/@2.4.3
         env:
           TF_VAR_node_env: production
           TF_VAR_supabase_jwt_secret: ${{ secrets.SUPABASE_JWT_SECRET }}


### PR DESCRIPTION
# Description

This PR sticking to the [2.4.3 tag version](https://github.com/WalletConnect/actions/releases) instead of the master branch in the shared `WalletConnect/actions` GitHub Action.

# Testing

Not tested.